### PR TITLE
Support IOS 26 - Versioning

### DIFF
--- a/BTProgressHUD/BTProgressHUD.csproj
+++ b/BTProgressHUD/BTProgressHUD.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0-ios</TargetFramework>
+        <TargetFramework>net10.0-ios</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>true</ImplicitUsings>
         <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>

--- a/pipelines/azure-pipeline.yml
+++ b/pipelines/azure-pipeline.yml
@@ -10,7 +10,7 @@ trigger:
 pr: none
 
 pool:
-  vmImage: 'macOS-14'
+  vmImage: 'macOS-15'
 
 resources:
   repositories:

--- a/pipelines/templates/build-dotnet-ios.yml
+++ b/pipelines/templates/build-dotnet-ios.yml
@@ -9,7 +9,7 @@ parameters:
     default: ''
   - name: dotNetSdkVersion
     type: string
-    default: '8.0.x'
+    default: '10.0.x'
   - name: iosWorkloadVersion
     type: string
     default: '10.0.102'

--- a/pipelines/templates/build-dotnet-ios.yml
+++ b/pipelines/templates/build-dotnet-ios.yml
@@ -9,7 +9,10 @@ parameters:
     default: ''
   - name: dotNetSdkVersion
     type: string
-    default: '8.0.x'   
+    default: '8.0.x'
+  - name: iosWorkloadVersion
+    type: string
+    default: '10.0.102'
   - name: publishWebProjects
     type: boolean
     default: true       
@@ -27,11 +30,11 @@ steps:
       packageType: sdk
 
   - task: Bash@3
-    displayName: 'dotnet workload restore'
+    displayName: 'Install IOS Workload'
     inputs:
       targetType: 'inline'
       script: |
-        dotnet workload restore '$(Build.SourcesDirectory)/${{ parameters.projectPath }}'
+        dotnet workload install ios --version '$(iosWorkloadVersion)'
     
   - task: DotNetCoreCLI@2
     displayName: '.NET Restore'

--- a/pipelines/templates/build-dotnet-ios.yml
+++ b/pipelines/templates/build-dotnet-ios.yml
@@ -34,7 +34,7 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
-        dotnet workload install ios --version '$(iosWorkloadVersion)'
+        dotnet workload install ios --version '${{parameters.iosWorkloadVersion}}'
     
   - task: DotNetCoreCLI@2
     displayName: '.NET Restore'


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

- Upgrade to dotnet 10
- Amend pipeline vm to latest
- Amend build process to use a pinned ios workload version


### :arrow_heading_down: What is the current behavior?
- Builds using dotnet 8
- IOS workload version is unspecified and just picks the latest that is supported by dotnet.

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
Hopefully shouldn't as it's just changing the dotnet version

### :bug: Recommendations for testing
Features should still be usable, once it has been built

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
